### PR TITLE
Workaround upstream helm/gRPC max message size

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -58,7 +58,8 @@ is_deployed() {
   if [ -n "$1" ]; then
     set +e
     set +o pipefail
-    helm history --tiller-namespace $tiller_namespace $1 2>&1 | grep "DEPLOYED" > /dev/null
+    # Note: drop the `--max 25` once this upstream helm issue is fixed (still broken in 2.8.1)
+    helm history --max 25 --tiller-namespace $tiller_namespace $1 2>&1 | grep "DEPLOYED" > /dev/null
     if [ $? = 0 ]; then
       # exists
       echo true


### PR DESCRIPTION
Workaround until this upstream helm commit makes it into a release:

https://github.com/kubernetes/helm/commit/98e5006ecfefe7c1b1ab10c9e9e906407101ded1